### PR TITLE
Corrected from_response

### DIFF
--- a/lib/afterpay/payment.rb
+++ b/lib/afterpay/payment.rb
@@ -21,9 +21,9 @@ module Afterpay
       @open_to_capture_amount = Utils::Money.from_response(attributes[:openToCaptureAmount]) || Money.from_amount(0)
       @payment_state = attributes[:paymentState] || ""
       @merchant_reference = attributes[:merchantReference] || ""
-      @refunds = attributes[:refunds].map { |refund| Refund.from_response(refund) } || [] if !attributes[:refunds].nil?
+      @refunds = attributes[:refunds].map { |refund| Refund.from_response(refund) } || [] unless attributes[:refunds].nil?
       @order = Order.from_response(attributes[:orderDetails]) || Afterpay::Order.new
-      @events = attributes[:events].map { |event| PaymentEvent.from_response(event) } || [] if !attributes[:events].nil?
+      @events = attributes[:events].map { |event| PaymentEvent.from_response(event) } || [] unless attributes[:events].nil?
       @error = Error.new(attributes) if attributes[:errorId]
     end
 

--- a/lib/afterpay/payment_event.rb
+++ b/lib/afterpay/payment_event.rb
@@ -8,15 +8,23 @@ module Afterpay
       @id = attributes[:id].to_i || ""
       @created = attributes[:created] || ""
       @expires = attributes[:expires] || ""
-      @type = attributes[:expires] || ""
-      @amount = Utils::Money.from_response(attributes[:amount]) || Money.from_amount(0)
+      @type = attributes[:type] || ""
+      @amount = attributes[:amount] || Money.from_amount(0)
       @payment_event_merchant_reference = attributes[:paymentEventMerchantReference] || ""
     end
 
     # Builds PaymentEvent from response
     def self.from_response(response)
       return nil if response.nil?
-      new(response)
+
+      new(
+        id: response[:id].to_i,
+        created: response[:created],
+        expires: response[:expires],
+        type: response[:type],
+        amount: Utils::Money.from_response(response[:amount]),
+        payment_event_merchant_reference: response[:paymentEventMerchantReference]
+      )
     end
   end
 end

--- a/lib/afterpay/refund.rb
+++ b/lib/afterpay/refund.rb
@@ -7,7 +7,7 @@ module Afterpay
 
     def initialize(attributes = {})
       @request_id = attributes[:requestId] || ""
-      @amount = attributes[:amount]
+      @amount = attributes[:amount] || Money.from_amount(0)
       @merchant_reference = attributes[:merchantReference] || ""
       @refund_id = attributes[:refundId] || ""
       @refunded_at = attributes[:refundAt] || ""
@@ -31,7 +31,15 @@ module Afterpay
     # Builds Refund from response
     def self.from_response(response)
       return nil if response.nil?
-      new(response)
+      new(
+        request_id: response[:requestId],
+        amount: Utils::Money.from_response(response[:amount]),
+        merchant_reference: response[:merchantReference],
+        refund_id: response[:refundId],
+        refunded_at: response[:refundAt],
+        refund_merchant_reference: response[:refundMerchantReference],
+        error: Error.new(response)
+      )
     end
   end
 end

--- a/lib/afterpay/refund.rb
+++ b/lib/afterpay/refund.rb
@@ -5,6 +5,8 @@ module Afterpay
     attr_accessor :request_id, :amount, :merchant_reference, :refund_id, :refunded_at,
                   :refund_merchant_reference, :error
 
+    # rubocop:disable Metrics/CyclomaticComplexity
+
     def initialize(attributes = {})
       @request_id = attributes[:requestId] || ""
       @amount = attributes[:amount] || Money.from_amount(0)
@@ -14,6 +16,8 @@ module Afterpay
       @refund_merchant_reference = attributes[:refundMerchantReference] || ""
       @error = Error.new(attributes) if attributes[:errorId]
     end
+
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     def self.execute(order_id:, amount:, request_id: nil, merchant_reference: nil,
                      refund_merchant_reference: nil)
@@ -31,6 +35,7 @@ module Afterpay
     # Builds Refund from response
     def self.from_response(response)
       return nil if response.nil?
+
       new(
         request_id: response[:requestId],
         amount: Utils::Money.from_response(response[:amount]),


### PR DESCRIPTION
This PR intends to correct the from_response method by not directly calling new with response but formatting the amount and then calling new with the attributes. The afterpay-sdk gem follows the Data Models attibutes data types as in v2 doc. As pe the doc amount attibute of Refund or PaymentEvent object is a Money object so when the developer calls new he need to supply the money object however we use from_response t method where we convert amount  in response to money object using utils.